### PR TITLE
Update dependencies

### DIFF
--- a/airplane-supplies/build.gradle
+++ b/airplane-supplies/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'io.spine.tools.gradle.bootstrap' version '1.4.0'
+    id 'io.spine.tools.gradle.bootstrap' version '1.5.21'
     id 'com.github.psxpaul.execfork' version '0.1.13'
 }
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -57,7 +57,7 @@ final def versions = [
         checkerFramework : '3.0.1',
         errorProne       : '2.3.4',
         errorProneJavac  : '9+181-r4173-1', // taken from here: https://github.com/tbroyer/gradle-errorprone-plugin/blob/v0.8/build.gradle.kts
-        errorPronePlugin : '1.1.1',
+        errorPronePlugin : '1.2.1',
         pmd              : '6.20.0',
         checkstyle       : '8.28',
         protobufPlugin   : '0.8.11',

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/security-checks/build.gradle
+++ b/security-checks/build.gradle
@@ -20,7 +20,7 @@
 
 plugins {
     id 'java'
-    id 'net.ltgt.errorprone' version '1.1.1'
+    id 'net.ltgt.errorprone' version '1.2.1'
     id 'com.github.psxpaul.execfork' version '0.1.13'
 }
 
@@ -30,7 +30,7 @@ dependencies {
 
     implementation (
             'com.google.code.gson:gson:2.8.6',
-            'com.sparkjava:spark-core:2.8.0',
+            'com.sparkjava:spark-core:2.9.1',
             deps.build.guava,
             deps.build.flogger,
             deps.build.jsr305Annotations,

--- a/takeoffs-and-landings/build.gradle
+++ b/takeoffs-and-landings/build.gradle
@@ -19,7 +19,7 @@
  */
 
 plugins {
-    id 'io.spine.tools.gradle.bootstrap' version '1.4.0'
+    id 'io.spine.tools.gradle.bootstrap' version '1.5.21'
     id 'application'
 }
 
@@ -33,7 +33,7 @@ sourceCompatibility = 1.8
 dependencies {
     protobuf project(':airplane-supplies')
     implementation deps.grpc.grpcNettyShaded
-    implementation "com.squareup.okhttp3:okhttp:4.3.1"
+    implementation "com.squareup.okhttp3:okhttp:4.7.2"
 }
 
 application {

--- a/takeoffs-and-landings/src/main/java/io/spine/example/airport/tl/AircraftAggregate.java
+++ b/takeoffs-and-landings/src/main/java/io/spine/example/airport/tl/AircraftAggregate.java
@@ -20,6 +20,7 @@
 
 package io.spine.example.airport.tl;
 
+import io.spine.core.External;
 import io.spine.example.airport.supplies.PreflightCheckComplete;
 import io.spine.server.aggregate.Aggregate;
 import io.spine.server.aggregate.Apply;
@@ -27,8 +28,8 @@ import io.spine.server.event.React;
 
 final class AircraftAggregate extends Aggregate<AircraftId, Aircraft, Aircraft.Builder> {
 
-    @React(external = true)
-    AircraftPreparedForFlight on(PreflightCheckComplete event) {
+    @React
+    AircraftPreparedForFlight on(@External PreflightCheckComplete event) {
         return AircraftPreparedForFlight
                 .newBuilder()
                 .setId(id())

--- a/takeoffs-and-landings/src/main/java/io/spine/example/airport/tl/FlightAggregate.java
+++ b/takeoffs-and-landings/src/main/java/io/spine/example/airport/tl/FlightAggregate.java
@@ -22,6 +22,7 @@ package io.spine.example.airport.tl;
 
 import com.google.protobuf.Timestamp;
 import io.spine.core.EventContext;
+import io.spine.core.External;
 import io.spine.example.airport.security.BoardingComplete;
 import io.spine.server.aggregate.Aggregate;
 import io.spine.server.aggregate.Apply;
@@ -74,8 +75,8 @@ final class FlightAggregate extends Aggregate<FlightId, Flight, Flight.Builder> 
                 .vBuild();
     }
 
-    @React(external = true)
-    EitherOf2<FlightRescheduled, Nothing> on(WindSpeedChanged event) {
+    @React
+    EitherOf2<FlightRescheduled, Nothing> on(@External WindSpeedChanged event) {
         double newDirection = event.getNewSpeed().getAzimuth();
         double previousDirection = event.getPreviousSpeed().getAzimuth();
         if (abs(previousDirection - newDirection) > WIND_DIRECTION_CHANGE_THRESHOLD) {
@@ -88,8 +89,8 @@ final class FlightAggregate extends Aggregate<FlightId, Flight, Flight.Builder> 
         return withB(nothing());
     }
 
-    @React(external = true)
-    EitherOf2<FlightRescheduled, Nothing> on(TemperatureChanged event) {
+    @React
+    EitherOf2<FlightRescheduled, Nothing> on(@External TemperatureChanged event) {
         float newTemperature = event.getNewTemperature().getDegreesCelsius();
         float previousTemperature = event.getPreviousTemperature().getDegreesCelsius();
         if (abs(previousTemperature - newTemperature) > TEMPERATURE_CHANGE_THRESHOLD) {

--- a/takeoffs-and-landings/src/main/java/io/spine/example/airport/tl/passengers/BoardingProcman.java
+++ b/takeoffs-and-landings/src/main/java/io/spine/example/airport/tl/passengers/BoardingProcman.java
@@ -20,6 +20,7 @@
 
 package io.spine.example.airport.tl.passengers;
 
+import io.spine.core.External;
 import io.spine.example.airport.security.BoardingComplete;
 import io.spine.example.airport.security.PassengerBoarded;
 import io.spine.example.airport.security.PassengerDeniedBoarding;
@@ -34,15 +35,15 @@ import static io.spine.server.tuple.EitherOf2.withB;
 
 public class BoardingProcman extends ProcessManager<FlightId, Boarding, Boarding.Builder> {
 
-    @React(external = true)
-    EitherOf2<BoardingComplete, Nothing> on(PassengerBoarded event) {
+    @React
+    EitherOf2<BoardingComplete, Nothing> on(@External PassengerBoarded event) {
         PassengerId passenger = event.getId();
         builder().addBoarded(passenger);
         return completeOrNothing();
     }
 
-    @React(external = true)
-    EitherOf2<BoardingComplete, Nothing> on(PassengerDeniedBoarding event) {
+    @React
+    EitherOf2<BoardingComplete, Nothing> on(@External PassengerDeniedBoarding event) {
         PassengerId passenger = event.getId();
         builder().addWillNotBeBoarded(passenger);
         return completeOrNothing();

--- a/weather/build.gradle
+++ b/weather/build.gradle
@@ -20,7 +20,7 @@
 
 plugins {
     id 'java'
-    id 'net.ltgt.errorprone' version '1.1.1'
+    id 'net.ltgt.errorprone' version '1.2.1'
     id 'com.github.psxpaul.execfork' version '0.1.13'
 }
 
@@ -30,7 +30,7 @@ dependencies {
 
     implementation (
             'com.google.code.gson:gson:2.8.6',
-            'com.sparkjava:spark-core:2.8.0',
+            'com.sparkjava:spark-core:2.9.1',
             deps.build.guava,
             deps.build.flogger,
             deps.build.jsr305Annotations,


### PR DESCRIPTION
This PR updates the version of the Bootstrap plugin to the most recent one: 1.5.21.

The usage of deprecated APIs has been eliminated.

This PR also updates some of the other dependencies, introducing no breaking changes or new deprecations.

The version of the Gradle wrapper has also been updated.